### PR TITLE
Add sd_product tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -11,6 +11,8 @@
 <html class="{{ view_mode }} {{ language_flags_mode }} {{ language_names_mode }} {{ language_menu_mode }} {{ site_search_mode }}" lang="{{ page.language_code }}">
   <head prefix="og: http://ogp.me/ns#">
     {% include "template-head" with "product_page" %}
+
+    {% sd_product %}
   </head>
 
   <body class="item-page product-page header-menu-wide">


### PR DESCRIPTION
Include `sd_product tag` in Auto-rendered Product layout to render out product structured data.

Closes #236