### PR TITLE
Display Voog reference only on front page

### DIFF
--- a/components/site-footer.tpl
+++ b/components/site-footer.tpl
@@ -3,7 +3,9 @@
   {%- assign footer_content_title_tooltip = "content_tooltip_all_pages_same_language" | lce -%}
   <div class="footer-body content-area js-footer-body">{% xcontent name="footer" title=footer_content_title title_tooltip=footer_content_title_tooltip %}</div>
 
-  <div class="voog-reference js-voog-reference">
-  	{% loginblock %}{{ "footer_login_link" | lc }}{% endloginblock %}
-  </div>
+  {% if site.branding.enabled and page.path == blank -%}
+    <div class="voog-reference js-voog-reference">
+      {% loginblock %}{{ "footer_login_link" | lc }}{% endloginblock %}
+    </div>
+  {% endif -%}
 </footer>


### PR DESCRIPTION
Voog reference is now displayed only on front page of site. If branding is turned off, then `voog-reference` container will not be rendered anymore.

Closes #246 